### PR TITLE
Support nested forms

### DIFF
--- a/app/views/trestle/mobility/_check_box.html.erb
+++ b/app/views/trestle/mobility/_check_box.html.erb
@@ -13,8 +13,8 @@
     <% locales.each do |locale| %>
       <%=
         content_tag(:div, "#{field_name.to_s.humanize} (#{locale.upcase})", { class: "form-control mobility-checkbox mobility-field#{locale == selected ? '' : ' hidden'}", data: { locale: locale } }) do
-          form.raw_check_box("#{field_name}_#{locale}", { class: "mobility-checkbox__input" }, "1", "0") +
-          form.label("#{field_name}_#{locale}", "#{label} (#{locale.upcase})", class: "mobility-checkbox__label")
+          builder.raw_check_box("#{field_name}_#{locale}", { class: "mobility-checkbox__input" }, "1", "0") +
+          builder.label("#{field_name}_#{locale}", "#{label} (#{locale.upcase})", class: "mobility-checkbox__label")
         end
       %>
     <% end %>

--- a/app/views/trestle/mobility/_text_area.html.erb
+++ b/app/views/trestle/mobility/_text_area.html.erb
@@ -10,7 +10,7 @@
     </ul>
     <% locales.each do |locale, index| %>
       <%=
-        form.raw_text_area(
+        builder.raw_text_area(
           "#{field_name}_#{locale}",
           options.merge(
             class: "form-control mobility-field#{locale == selected ? '' : ' hidden'}",

--- a/app/views/trestle/mobility/_text_field.html.erb
+++ b/app/views/trestle/mobility/_text_field.html.erb
@@ -12,7 +12,7 @@
     </div>
     <% locales.each do |locale| %>
       <%=
-        form.raw_text_field(
+        builder.raw_text_field(
           "#{field_name}_#{locale}",
           options.merge(
             class: "form-control mobility-field#{locale == selected ? '' : ' hidden'}",

--- a/lib/trestle/mobility/fields/check_box.rb
+++ b/lib/trestle/mobility/fields/check_box.rb
@@ -9,6 +9,7 @@ module Trestle
 
           @template.render partial: "trestle/mobility/check_box",
                            locals: {
+                             builder: builder,
                              field_name: name,
                              label: label,
                              locales: locales,

--- a/lib/trestle/mobility/fields/text_area.rb
+++ b/lib/trestle/mobility/fields/text_area.rb
@@ -14,6 +14,7 @@ module Trestle
 
           @template.render partial: "trestle/mobility/text_area",
                            locals: {
+                             builder: builder,
                              options: options,
                              field_name: name,
                              label: label,

--- a/lib/trestle/mobility/fields/text_field.rb
+++ b/lib/trestle/mobility/fields/text_field.rb
@@ -10,6 +10,7 @@ module Trestle
 
           @template.render partial: "trestle/mobility/text_field",
                            locals: {
+                             builder: builder,
                              options: options,
                              field_name: name,
                              label: label,


### PR DESCRIPTION
The current implementation does not support nested forms, as it will try to create the fields for the parent model instead of the child model. By using the `builder` method in the custom field as described here https://github.com/TrestleAdmin/trestle/wiki/How-To:-Make-a-Custom-Form-Field this also works for nested fields.