### PR TITLE
Ability to customise placeholder on the fields.

### DIFF
--- a/app/views/trestle/mobility/_text_area.html.erb
+++ b/app/views/trestle/mobility/_text_area.html.erb
@@ -16,7 +16,7 @@
           "#{field_name}_#{locale}",
           options.merge(
             class: "form-control mobility-field#{locale == selected ? '' : ' mobility-field--hidden'}",
-            placeholder: "#{label} (#{locale.upcase})",
+            placeholder: options[:placeholder] || "#{label} (#{locale.upcase})",
             data: { locale: locale }
           )
         )

--- a/app/views/trestle/mobility/_text_field.html.erb
+++ b/app/views/trestle/mobility/_text_field.html.erb
@@ -16,7 +16,7 @@
           "#{field_name}_#{locale}",
           options.merge(
             class: "form-control mobility-field#{locale == selected ? '' : ' mobility-field--hidden'}",
-            placeholder: "#{label} (#{locale.upcase})",
+            placeholder: options[:placeholder] || "#{label} (#{locale.upcase})",
             data: { locale: locale }
           )
         )


### PR DESCRIPTION
This PR should add the ability for providing a placeholder as an option to the field. 

Right now we are generating placeholder by combining `label` and `selected locale` [read here](https://github.com/asad-ali-bhatti/trestle-mobility/blob/86f6b674a645cdf52a2466f2b1308e3bea2b5b8b/app/views/trestle/mobility/_text_area.html.erb#L19). 
 
In our project, we need to show a placeholder explaining to the user what he is supposed to write in this field. which is different than the label and much longer than that. I think it makes more sense to let users enter whatever they want as a placeholder to the field.  

Along with this addition, I kept the existing functionality that if the user doesn't provide a placeholder we render `field_name + selected locale`. 