### PR TITLE
Compatibilty with mobility 1.x

### DIFF
--- a/trestle-mobility.gemspec
+++ b/trestle-mobility.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "emoji_flag", "~> 0.1"
-  spec.add_dependency "mobility", "~> 0.8"
+  spec.add_dependency "mobility", ">= 0.8"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
This PR relaxes the version constraint on Mobility, hence allowing it to be used with any Mobility version >= 0.8 (including the 1.x series). 

I haven't found any compatibility issues with Mobility 1.2 in our project so far.